### PR TITLE
use debounce in the right way

### DIFF
--- a/lib/color.coffee
+++ b/lib/color.coffee
@@ -51,9 +51,12 @@ module.exports =
 
   activate: (state) ->
     atom.workspace.observeTextEditors (editor) =>
-      editor.onDidChange @compile.bind(@, editor)
+      compile = @compile.bind(@, editor)
+      # editor.onDidChange debouncedCompile
+      editor.onDidStopChanging compile
+      _.defer compile
 
-  compile: _.debounce((_editor, context) ->
+  compile: (_editor, context) ->
     view = $(atom.views.getView(_editor))
     shadow = $(view[0].shadowRoot)
     fill = atom.config.get "webbox-color.fillColorAsBackground"
@@ -89,4 +92,3 @@ module.exports =
               width: (size * line) - 4
               height: (size * line) - 4
             curLine.append colorBox
-  , 100)

--- a/lib/color.coffee
+++ b/lib/color.coffee
@@ -51,15 +51,9 @@ module.exports =
 
   activate: (state) ->
     atom.workspace.observeTextEditors (editor) =>
-      _editor = editor
-      editor.onDidChange =>
-        _.debounce (=> @compile(_editor)), 100
-        setInterval =>
-          @compile(_editor)
-        , 1000
-        @compile(_editor)
+      editor.onDidChange @compile.bind(@, editor)
 
-  compile: (_editor, context)->
+  compile: _.debounce((_editor, context) ->
     view = $(atom.views.getView(_editor))
     shadow = $(view[0].shadowRoot)
     fill = atom.config.get "webbox-color.fillColorAsBackground"
@@ -95,3 +89,4 @@ module.exports =
               width: (size * line) - 4
               height: (size * line) - 4
             curLine.append colorBox
+  , 100)


### PR DESCRIPTION
I found it's very slow when typing in atom(in my old macbook), after profile javascript I found this and fix it.

1. `_.debounce (=> @compile(_editor)), 100` here just create a debounced version of this function but never call it! The right way is create one debounced version of `@compile`.
see the [doc](http://underscorejs.org/#debounce)

2. I think `editor.onDidChange` will be called every time the text is changed, so you needn't call `setInterval` in this callback, just call debounced version of `compile` instead.

---

Update: I found the new api `editor.onDidStopChanging` already do the work of debounce did.
